### PR TITLE
Enable Tampermonkey auto-updates from GitHub raw URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Tampermonkey 向けに開発された、X（旧 Twitter）のプロフィール「メディア」タブで投稿単位のメディアを収集・一括ダウンロードするユーザースクリプトです。今後の実装は「URL 収集 → メディア解析 → ZIP ダウンロード」の 3 段階に整理されています。
 
+## インストール
+
+1. Tampermonkey をブラウザにインストールします。
+2. 次の raw URL をブラウザで開きます。
+   - `https://github.com/japan4415/x-photo-video-collector-tempermonkey/raw/main/x-photo-video-collector.user.js`
+3. Tampermonkey のインストール画面が開いたら、そのままインストールします。
+
+この方法でインストールした場合、以後は `@updateURL` / `@downloadURL` により自動更新を受け取れます。
+
+## 自動更新について
+
+- 配布ファイルは `x-photo-video-collector.user.js` です。
+- GitHub `main` 上の raw URL を `@updateURL` / `@downloadURL` に設定しています。
+- 更新を配布する際はユーザースクリプトヘッダの `@version` を上げてください。
+- すでにコードをコピーペーストして登録している場合、自動更新は有効になりません。上記 raw URL から再インストールしてください。
+- Tampermonkey のダッシュボードから `Check for userscript updates` でも更新確認できます。
+
 ## 概要
 
 - 対象ページ: `https://x.com/<screenName>/media`

--- a/x-photo-video-collector.user.js
+++ b/x-photo-video-collector.user.js
@@ -1,13 +1,15 @@
 // ==UserScript==
-// @name         X Profile Media UI (Top-right Panel) - Solid AutoScroll & List
-// @namespace    your-namespace
-// @version      0.4.0
-// @description  On x.com/<user>/media: robust auto-scroll (detects real scroller, with scrollIntoView fallback), then list filenames (IMG + MP4; no m3u8).
+// @name         X Photo Video Collector
+// @namespace    https://github.com/japan4415/x-photo-video-collector-tempermonkey
+// @version      0.4.1
+// @description  Collect media post URLs and direct image/mp4 links from X profile media tabs.
 // @match        https://x.com/*
 // @run-at       document-idle
 // @grant        GM_openInTab
 // @grant        GM_setValue
 // @grant        GM_addValueChangeListener
+// @updateURL    https://github.com/japan4415/x-photo-video-collector-tempermonkey/raw/main/x-photo-video-collector.user.js
+// @downloadURL  https://github.com/japan4415/x-photo-video-collector-tempermonkey/raw/main/x-photo-video-collector.user.js
 // @noframes
 // ==/UserScript==
 


### PR DESCRIPTION
## Summary
- rename the distributable userscript to `x-photo-video-collector.user.js`
- add `@updateURL` and `@downloadURL` metadata pointing at the GitHub raw URL
- document raw-url installation and the reinstallation requirement for existing copy-paste users

## Validation
- GitHub checks: no checks reported on this branch
- Syntax check: `node --check x-photo-video-collector.user.js`
- Browser install/update flow: not run (requires manual Tampermonkey verification)