### PR TITLE
Fix multi-image media extraction via photo count fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Tampermonkey 向けに開発された、X（旧 Twitter）のプロフィール�
   - フェッチ結果が `JavaScriptを使用できません。` のプレースホルダだった場合は、該当ツイート詳細を新しいアクティブタブで開いて DOM から再解析
   - `<img>` の `src`、`background-image`、および `<video>/<source>` の `src` を抽出
   - 動画 URL を DOM から確定できない場合は `TweetResultByRestId` API の `video_info.variants` から MP4 を補完
+  - 複数画像ツイートで DOM から一部の画像しか取得できない場合（遅延ロードにより全画像が含まれないケース）は、同じ GraphQL API フォールバックで全画像を補完
   - 画像は `?name=orig`、`format` パラメータで正規化、動画は `.mp4` のみ対象
   - ツイート内での順序・種別をメタ情報として保持
   - 次のツイートへ進む前に既定で 10 秒待機し、パネルの設定値で変更可能

--- a/x-photo-video-collector.user.js
+++ b/x-photo-video-collector.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         X Photo Video Collector
 // @namespace    https://github.com/japan4415/x-photo-video-collector-tempermonkey
-// @version      0.5.3
+// @version      0.5.4
 // @description  Collect media post URLs and direct image/mp4 links from X profile media tabs.
 // @match        https://x.com/*
 // @run-at       document-idle
@@ -1166,7 +1166,8 @@
   }
 
   function analyzeMediaHints(card) {
-    const hasPhoto = !!(card.querySelector('a[href*="/photo/"]') || card.querySelector('img[src*="pbs.twimg.com/"]'));
+    const photoLinks = card.querySelectorAll('a[href*="/photo/"]');
+    const hasPhoto = !!(photoLinks.length || card.querySelector('img[src*="pbs.twimg.com/"]'));
     const hasVideo = !!(card.querySelector('a[href*="/video/"]') || card.querySelector('video, source[src*="video.twimg.com"]'));
     const iconPath = card.querySelector('a[href*="/status/"] svg path');
     const pathD = iconPath?.getAttribute('d') || '';
@@ -1175,7 +1176,8 @@
       hasMedia: hasPhoto || hasVideo,
       hasPhoto,
       hasVideo,
-      isMulti
+      isMulti,
+      photoCount: photoLinks.length
     };
   }
 
@@ -1193,7 +1195,11 @@
     const tryApiFallback = async (items, reason) => {
       const currentItems = Array.isArray(items) ? items : [];
       const hasVideo = currentItems.some(item => item?.type === 'mp4');
-      const shouldFetchApi = currentItems.length === 0 || (tweet?.hints?.hasVideo && !hasVideo);
+      const imgCount = currentItems.filter(item => item?.type === 'img').length;
+      const expectedPhotos = tweet?.hints?.photoCount ?? 0;
+      const shouldFetchApi = currentItems.length === 0
+        || (tweet?.hints?.hasVideo && !hasVideo)
+        || (expectedPhotos > 1 && imgCount < expectedPhotos);
       if (!shouldFetchApi) return currentItems;
       const apiItems = await fetchTweetMediaViaApi(tweet);
       if (!apiItems.length) return currentItems;


### PR DESCRIPTION
Closes #12

## 概要

複数画像ツイートで3枚目以降のメディアが取得されない問題を修正します。

## 根本原因

1. ツイート詳細の HTML を fetch しても、画像カルーセルは遅延ロードのため先頭2枚しか `<img>` が含まれない（`sample2.html` で確認済み）
2. API フォールバックの発火条件が `currentItems.length === 0 || (hints.hasVideo && !hasVideo)` のみで、部分取得（4枚中2枚など）をカバーしていなかった

## 修正内容（Issue 記載の案2）

- `analyzeMediaHints` で `card.querySelectorAll('a[href*="/photo/"]')` の件数を `hints.photoCount` として記録
- `tryApiFallback` の発火条件に「`photoCount > 1` かつ取得済み img 件数 < `photoCount`」を追加。API 側の `collectMediaFromTweetResult` は `legacy.extended_entities.media` を参照済みのため、フォールバックが発火すれば全枚数取得できる
- `@version` を 0.5.3 → 0.5.4 に更新（raw/main 直配布のため自動更新に必要）
- README のメディア解析セクションに補完動作を追記

## 受け入れ条件の検証（静的検証 + 多観点レビュー）

- 4枚画像ツイート: DOM から2枚のみ取得 → `imgCount(2) < photoCount(4)` で API フォールバック発火 → `extended_entities.media` から4枚取得 ✅
- 2〜3枚ツイート: 同様に不足分を API 補完 ✅
- 単画像ツイート: `photoCount = 1` のため `photoCount > 1` が false となり、新条件は発火せず API 呼び出しは増えない ✅
- `hints` を持たない tweet オブジェクトでは `?? 0` により新条件は無効化され安全
- `hasPhoto` の `querySelector` → `querySelectorAll(...).length` 変更は真偽値として完全に同一挙動（回帰なし）
- API 失敗時は `if (!apiItems.length) return currentItems;` により既存取得分が保持される

## 既知の軽微な制限（レビューで検出、実害は限定的）

- 引用ツイートを含むカードでは引用側の photo リンクが `photoCount` に混入し過大計上される可能性があるが、`mergeMediaItems` の `type|url` キーによる重複除去が効くため最終結果は壊れず、余分な API 呼び出しが1回発生するのみ

## テスト

自動テスト・CI なし（Tampermonkey への手動コピペが必要）のため、`node --check` による構文検証と、correctness / 回帰・エッジケースの2観点並列コードレビューで品質担保しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)